### PR TITLE
Use package-relative imports for src modules

### DIFF
--- a/scripts/pose2vid_xnemo.py
+++ b/scripts/pose2vid_xnemo.py
@@ -26,14 +26,14 @@ from omegaconf import OmegaConf
 from PIL import Image
 from torchvision import transforms
 from transformers import CLIPVisionModelWithProjection
-from src.models.unet_2d_condition import UNet2DConditionModel
-from src.models.unet_3d import UNet3DConditionModel
-from src.pipelines.pipeline_pose2vid_motenc_long import Pose2VideoPipeline
-from src.utils.util import save_videos_grid
+from ..src.models.unet_2d_condition import UNet2DConditionModel
+from ..src.models.unet_3d import UNet3DConditionModel
+from ..src.pipelines.pipeline_pose2vid_motenc_long import Pose2VideoPipeline
+from ..src.utils.util import save_videos_grid
 from decord import VideoReader
 from scipy.ndimage import gaussian_filter1d
 
-from src.models.motion_encoder.encoder import MotEncoder_withExtra as MotEncoder
+from ..src.models.motion_encoder.encoder import MotEncoder_withExtra as MotEncoder
 
 
 def check_oob_new(bbox, frame_shape):

--- a/scripts/vid2pose.py
+++ b/scripts/vid2pose.py
@@ -8,10 +8,10 @@ from PIL import Image
 import cv2
 from tqdm import tqdm
 
-from src.utils.util import get_fps, read_frames, save_videos_from_pil
+from ..src.utils.util import get_fps, read_frames, save_videos_from_pil
 import numpy as np
-from src.utils.draw_util import FaceMeshVisualizer
-from src.utils.mp_utils  import LMKExtractor
+from ..src.utils.draw_util import FaceMeshVisualizer
+from ..src.utils.mp_utils  import LMKExtractor
 import mediapipe as mp
 from mediapipe.framework.formats import landmark_pb2
 

--- a/xnemo_comfy_node.py
+++ b/xnemo_comfy_node.py
@@ -12,12 +12,12 @@ from PIL import Image
 from scipy.ndimage import gaussian_filter1d
 
 from .scripts.vid2pose import extract_bbox_mp
-from src.models.motion_encoder.encoder import (
+from .src.models.motion_encoder.encoder import (
     MotEncoder_withExtra as MotEncoder,
 )
-from src.models.unet_2d_condition import UNet2DConditionModel
-from src.models.unet_3d import UNet3DConditionModel
-from src.pipelines.pipeline_pose2vid_motenc_long import Pose2VideoPipeline
+from .src.models.unet_2d_condition import UNet2DConditionModel
+from .src.models.unet_3d import UNet3DConditionModel
+from .src.pipelines.pipeline_pose2vid_motenc_long import Pose2VideoPipeline
 
 try:
     from transformers import CLIPVisionModelWithProjection


### PR DESCRIPTION
## Summary
- switch the ComfyUI node to import its internal models and pipeline via `.src` so it resolves through the package
- update the helper scripts to use `..src` imports so they work when installed as a custom node package

## Testing
- `python -c "import xnemo_comfy_node"` *(fails: ModuleNotFoundError: No module named 'mediapipe')*

------
https://chatgpt.com/codex/tasks/task_e_68db5026862c832bae3711ab20e714c7